### PR TITLE
Use cantaloupe docker image for local development

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,17 @@
+# Put your AWS credentials here or set them via AWS_PROFILE
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_KEY=
+
+# Common variables
+LOG_APPLICATION_LEVEL=warn
+HTTP_HTTP2_ENABLED=true
+
+# Uncomment this block to use the DCE S3 bucket
+S3CACHE_BUCKET_NAME=yale-image-samples/cantaloupe/cache
+S3_SOURCE_BUCKET_NAME=yale-image-samples
+PAIRTREE_PATH=false
+
+# Uncomment this block to use the Yale S3 bucket
+# S3CACHE_BUCKET_NAME=yale-image-samples/cantaloupe/cache
+# S3_SOURCE_BUCKET_NAME=yale-image-samples
+# PAIRTREE_PATH=true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # 🍈 Cantaloupe - Docker image build
 
 Docker build for Cantaloupe IIIF image server.
@@ -7,7 +6,16 @@ Sample URL:
 
 `http://127.0.0.1:8182/iiif/2/1014333/full/512,/0/default.jpg`
 
-# Build an image
+## Use for local development
+
+1. Clone this repo: `git clone git@github.com:yalelibrary/yul-dc-iiif-imageserver.git`
+2. Edit `.env` -- add your AWS credentials and uncomment the block for the Yale or DCE S3 bucket
+3. Build the container: `docker-compose build web`
+4. Run the container: `docker-compose up web`
+
+You should now be able to go to `http://127.0.0.1:8182/iiif/2/1014333/full/512,/0/default.jpg` in your browser and see an image.
+
+## Build an image
 
 ```
 docker image build -t registryaccount/name:tag .
@@ -38,7 +46,7 @@ All image keys are prefixed with `ptiffs`
 
 ## Pairtree
 
-Identifiers are assumed to be numeric OIDs.  Last 2 digits are placed first for randomness.  If the OID is made up of an odd number of digits, the final digit is ignored when constructing the pairtree path.  
+Identifiers are assumed to be numeric OIDs. Last 2 digits are placed first for randomness. If the OID is made up of an odd number of digits, the final digit is ignored when constructing the pairtree path.
 
 For example:
 
@@ -52,5 +60,4 @@ Assumes images are TIFF and end with the `.tif` extension.
 
 # License
 
-Cantaloupe is open-source software distributed under the University of
-Illinois/NCSA Open Source License; see the file LICENSE.txt for terms.
+Cantaloupe is open-source software distributed under the University of Illinois/NCSA Open Source License; see the file LICENSE.txt for terms.

--- a/delegates.rb
+++ b/delegates.rb
@@ -219,14 +219,34 @@ class CustomDelegate
   #
   def s3source_object_info(options = {})
     identifier = context['identifier']
-    prefix = identifier[-2..-1]
-    parts = identifier.scan(/../)
-    digest_path_structure = *["ptiffs", prefix, parts, identifier]
     bucket = ENV['S3_SOURCE_BUCKET_NAME']
     info = Hash.new()
     info['bucket'] = bucket
-    info['key'] = digest_path_structure.join('/') + '.tif'
+    info['key'] = image_path
     info
+  end
+
+  # The Yale S3 bucket has images organized into pairtrees, but the DCE folder does not
+  # We need a way to switch between them when we're working.
+  def image_path
+    if ENV['PAIRTREE_PATH']
+      pairtree_path
+    else
+      simple_path
+    end
+  end
+
+  def simple_path
+    identifier = context['identifier']
+    "ptiffs/#{identifier}.tif"
+  end
+
+  def pairtree_path
+    identifier = context['identifier']
+    prefix = identifier[-2..-1]
+    parts = identifier.scan(/../)
+    digest_path_structure = *["ptiffs", prefix, parts, identifier]
+    digest_path_structure.join('/') + '.tif'
   end
 
   ##

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2.1'
+services:
+
+  web:
+    build: .
+    image: "yalelibraryit/dc-iiif-cantaloupe:latest"
+    env_file:
+      - .env
+    ports:
+      - "8182:8182"
+    stdin_open: true
+    # Enable sending signals (CTRL+C, CTRL+P + CTRL+Q) into the container:
+    tty: true


### PR DESCRIPTION
1. Add the ability to swich between the Yale S3 and the DCE S3 image buckets. The Yale bucket uses pairtrees but the DCE bucket does not. We can now toggle between them using the PAIRTREE_PATH variable in .env
2. Add setup instructions for new developers
3. Add a docker-compose file to easily load this container and make it available locally

Connected to https://github.com/yalelibrary/YUL-DC/issues/80