### PR TITLE
Require pairtree layout

### DIFF
--- a/.env
+++ b/.env
@@ -9,9 +9,4 @@ HTTP_HTTP2_ENABLED=true
 # Uncomment this block to use the DCE S3 bucket
 S3CACHE_BUCKET_NAME=yale-image-samples/cantaloupe/cache
 S3_SOURCE_BUCKET_NAME=yale-image-samples
-PAIRTREE_PATH=false
 
-# Uncomment this block to use the Yale S3 bucket
-# S3CACHE_BUCKET_NAME=yale-image-samples/cantaloupe/cache
-# S3_SOURCE_BUCKET_NAME=yale-image-samples
-# PAIRTREE_PATH=true

--- a/delegates.rb
+++ b/delegates.rb
@@ -226,22 +226,8 @@ class CustomDelegate
     info
   end
 
-  # The Yale S3 bucket has images organized into pairtrees, but the DCE folder does not
-  # We need a way to switch between them when we're working.
+  # Use pairtree layout, but the DCE folder does not
   def image_path
-    if ENV['PAIRTREE_PATH']
-      pairtree_path
-    else
-      simple_path
-    end
-  end
-
-  def simple_path
-    identifier = context['identifier']
-    "ptiffs/#{identifier}.tif"
-  end
-
-  def pairtree_path
     identifier = context['identifier']
     prefix = identifier[-2..-1]
     parts = identifier.scan(/../)


### PR DESCRIPTION
**Description**
See #2 and yalelibrary/YUL-DC#111 
Removes the optional "flat" filesystem layout for PTIFFs.

**Test**
Run the server: set up AWS credentials, `docker-compose build`, `docker-compose up`

Request the test image (ID 14716457) in a random permutation of IIIF size/rotation (to avoid receiving cached data):

http://127.0.0.1:8182/iiif/2/1014333/full/432,/0/default.jpg

![14716457](https://user-images.githubusercontent.com/1987952/82092592-94f58c80-96c7-11ea-8abd-3b3f4d3eba13.jpg)
N.B. The test image has been removed from the root of the filesystem so won't work without the pairtree path.