### PR TITLE
Add automated docker image building through circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,78 @@
+commands:
+  docker-tag:
+    description: "Add a new tag to a docker image that has already been pulled"
+    parameters:
+      from_tag:
+        type: string
+        default: $CIRCLE_SHA1
+      to_tag:
+        type: string
+        default: "master"
+      image:
+        type: string
+    steps:
+      - run: >
+          docker tag <<parameters.image>>:<<parameters.from_tag>> <<parameters.image>>:<<parameters.to_tag>>
+
+jobs:
+  build-and-push:
+    executor: docker/docker
+    steps:
+      - setup_remote_docker
+      - checkout
+      - docker/check
+      - docker/build:
+          image: yalelibraryit/dc-iiif-cantaloupe
+          cache_from: yalelibraryit/dc-iiif-cantaloupe:master
+      - docker/push:
+          image: yalelibraryit/dc-iiif-cantaloupe
+
+  publish-latest:
+    executor: docker/docker
+    steps:
+      - setup_remote_docker
+      - docker/check
+      - docker/pull:
+          images: yalelibraryit/dc-iiif-cantaloupe:$CIRCLE_SHA1
+      - docker-tag:
+          image: yalelibraryit/dc-iiif-cantaloupe
+          from_tag: $CIRCLE_SHA1
+          to_tag: $CIRCLE_BRANCH
+      - docker/push:
+          image: yalelibraryit/dc-iiif-cantaloupe
+          tag: $CIRCLE_BRANCH
+  publish-github-release:
+    executor: docker/docker
+    steps:
+      - setup_remote_docker
+      - docker/check
+      - docker/pull:
+          images: yalelibraryit/dc-iiif-cantaloupe:$CIRCLE_SHA1
+      - docker-tag:
+          image: yalelibraryit/dc-iiif-cantaloupe
+          from_tag: $CIRCLE_SHA1
+          to_tag: $CIRCLE_TAG
+      - docker/push:
+          image: yalelibraryit/dc-iiif-cantaloupe
+          tag: $CIRCLE_TAG
+
+
+orbs:
+  docker: circleci/docker@1.0.1
+version: 2.1
+workflows:
+  commit:
+    jobs:
+      - build-and-push:
+          context: yul-dc
+      - publish-latest:
+          context: yul-dc
+          requires:
+            - build-and-push
+      - publish-github-release:
+          context: yul-dc
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+$/

--- a/jmeter/examples.txt
+++ b/jmeter/examples.txt
@@ -1,5 +1,5 @@
 USERS=5; RAMP=100; LENGTH=200; HEAP="-Xms1g -Xmx10g" jmeter -n -t iiif-test-plan-arbitrary-requests.jmx \
--l "./results/results-${USERS}-${RAMP}-${LENGTH}.log" -j "./results/logfile-${USERS}-${RAMP}-${LENGTH}.log" 
+-l "./results/results-${USERS}-${RAMP}-${LENGTH}.log" -j "./results/logfile-${USERS}-${RAMP}-${LENGTH}.log"
 -Jusers=$USERS  -Jramp=$RAMP -Jlength=$LENGTH -Jserver=56.211.80.243 -Jport 8182
 
 USERS=50; RAMP=100; LENGTH=200; HEAP="-Xms1g -Xmx10g" jmeter -n -t iiif-test-plan-UV-only.jmx -l "./results/results-${USERS}-${RAMP}-${LENGTH}.log" -j "./results/logfile-${USERS}-${RAMP}-${LENGTH}.log" -Jusers=$USERS -Jramp=$RAMP -Jlength=$LENGTH -Jserver=54.211.80.243 -Jport 8182


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21695512/87331597-39e5e780-c508-11ea-8ca1-dc630d364794.png)
The 2nd and 3rd docker tags in this screenshots were generated by circleci building on the circle-build branch of this repo.  Circleci config file cribbed from yul-dc-blacklight, modified to eliminate the run-tests job (we'll want to add one, but I don't have something for it to do yet) and to use the right dockerhub image name for this service.